### PR TITLE
Fix Buda Sync

### DIFF
--- a/screens/BudaAuthScreen/BudaAuthScreen.js
+++ b/screens/BudaAuthScreen/BudaAuthScreen.js
@@ -12,7 +12,11 @@ import {
 } from 'react-native-elements';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
-import { BUDA_AUTH_REQUEST, BUDA_CLEAN_ERROR } from '../../store/types';
+import {
+  BUDA_AUTH_REQUEST,
+  BUDA_CLEAN_ERROR,
+  GET_WALLETS_BALANCES,
+} from '../../store/types';
 import styles from './styles';
 import Theme from '../../styles/Theme';
 import colors from '../../styles/colors';
@@ -31,6 +35,7 @@ function BudaAuthScreen() {
       payload: { apiKey, apiSecret, password },
       callback: () => {
         navegation.goBack();
+        dispatch({ type: GET_WALLETS_BALANCES });
       },
     });
   }


### PR DESCRIPTION
No se estaba pidiendo el balance de las wallets despues de sincronizar las credenciales de buda, esto causaba errores en otras pantallas. 